### PR TITLE
update: instead of heroku command, use docker's action to deploy

### DIFF
--- a/.github/workflows/deploy_to_heroku.yml
+++ b/.github/workflows/deploy_to_heroku.yml
@@ -3,25 +3,31 @@ on:
   push:
     branches:
       - main
+  # for debug
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/deploy_to_heroku.yml
 
 jobs:
   build-and-push:
     name: build and push
     runs-on: ubuntu-latest
     steps:
-    - name: checkout
-      uses: actions/checkout@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: Login to Heroku Container Registry
       uses: docker/login-action@v1
       with:
         registry: registry.heroku.com
         username: ${{ secrets.heroku_username }}
         password: ${{ secrets.heroku_password }}
+
     - name: Push to Heroku Container Registry
-      run: |
-        heroku container:push -a=gslide-presen-share web
-      working-directory: gcp/page_sync_backend
-    - name: Release pushed container
-      run: |
-        heroku container:release -a=gslide-presen-share web
-      working-directory: gcp/page_sync_backend
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: registry.heroku.com/gslide-presen-share/web
+        context: ./gcp/page_sync_backend


### PR DESCRIPTION
## 概要

* herokuコマンドでなく、docker actionsでコンテナイメージをpushする
* heroku releaseを一回無くす（これだけなら一応手作業でもできるので）