### PR TITLE
backendのformatterやlinterの設定移動

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -20,14 +20,14 @@ build:
 	docker build -t page_sync_backend:latest .
 
 format:
-	poetry run isort . --skip .venv
-	poetry run black . --exclude .venv
+	poetry run isort .
+	poetry run black .
 
 test:
 	poetry run pytest tests
 
 lint:
-	poetry run mypy . --exclude .venv
-	poetry run flake8 . --exclude .venv
+	poetry run mypy .
+	poetry run flake8
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from uuid import uuid4
 
-from fastapi import FastAPI, Path, status, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Path, WebSocket, WebSocketDisconnect, status
 from fastapi.exceptions import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,19 @@ mypy = "^0.910"
 black = "^21.7b0"
 requests = "^2.26.0"
 
+[tool.black]
+line-length = 127
+
+[tool.isort]
+profile = "black"
+extend_skip = ".pytest_cache"
+
+[tool.mypy]
+
+[[tool.mypy.overrides]]
+module = "pytest.*"
+ignore_missing_imports = true
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -2,10 +2,13 @@
 max-line-length = 127
 extend-ignore = E203, W503, N802
 
-[mypy]
+# __pycache__はデフォルトのexcludeに入っている
+extend-exclude =
+    .mypy_cache,
+    .pytest_cache,
+    .venv
 
-[mypy-pytest.*]
-ignore_missing_imports = True
-
-[isort]
-profile=black
+# __init__.pyでは、ファイル内で試用しないimport文 (F401) と、
+# from package import * (F403) を許す
+per-file-ignores =
+    */__init__.py:F401,F403


### PR DESCRIPTION
## 概要

* setup.cfgからpyproject.tomlに移動して、設定項目を見直す

## やったこと

* [x] backendのformatterやlinter（flake8除く）の設定をsetup.cfgからpyproject.tomlに移動
* [x] 不要なファイル指定をMakefileから削除
* [x] formatterの適用漏れがあったので適用

## やらないこと

* CIのワークフロー追加